### PR TITLE
feat: 支持腾讯云 EdgeOne Pages 部署（实现 Cloudflare & EdgeOne 双平台兼容）

### DIFF
--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: deploy
+description: 部署到 Cloudflare Workers
+license: MIT
+metadata:
+  version: "1.0.0"
+  author: QingChen Cloud
+  tags: ["cloudflare", "workers", "deploy"]
+---
+# 部署 Deploy
+
+部署到 Cloudflare Workers。
+
+## 流程
+
+1. 检查是否已安装依赖（node_modules 是否存在），未安装则执行 `npm install`
+2. 执行 `npm run deploy`（即 `wrangler deploy`）
+3. 输出部署结果：Worker URL、部署状态
+
+## 本地预览
+
+如需本地测试，执行 `npm run dev`（即 `wrangler dev`），默认监听 `http://localhost:8787`。
+
+## 搭配 cftunnel
+
+本地开发时可用 `cftunnel quick 8787` 生成临时公网地址，方便远程调试。

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: release
+description: 版本发布：bump 版本号 → npm publish → git tag → push
+license: MIT
+metadata:
+  version: "1.0.0"
+  author: QingChen Cloud
+  tags: ["npm", "release", "publish"]
+---
+# 发版 Release
+
+发布新版本到 npm 并推送到 GitHub。
+
+## 流程
+
+1. 确认当前工作区干净（无未提交变更）
+2. 询问版本号类型：patch / minor / major
+3. 执行 `npm version <type>` 自动更新 package.json 并创建 git tag
+4. 执行 `npm publish` 发布到 npm
+5. 执行 `git push && git push --tags` 推送代码和标签到 GitHub
+6. 输出发布摘要：版本号、npm 地址、GitHub tag 地址
+
+## 注意事项
+
+- npm 包名为 `@qingchencloud/cj2api`，scoped public 包
+- 发布前确保 `npm whoami` 已登录且属于 `@qingchencloud` 组织
+- 如果有 TypeScript 编译错误，先修复再发版

--- a/.agents/skills/update-page/SKILL.md
+++ b/.agents/skills/update-page/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: update-page
+description: 维护内置测试页面（page.ts）
+license: MIT
+metadata:
+  version: "1.0.0"
+  author: QingChen Cloud
+  tags: ["frontend", "page", "ui"]
+---
+# 更新测试页面 Update Page
+
+修改内置测试页面（src/page.ts）。
+
+## 页面结构
+
+- 头部：标题 + 版本徽章 + ChatJimmy 链接 + API Key 提示
+- 接口端点卡片：POST /v1/chat/completions、GET /v1/models
+- 四个 Tab：测试面板、cURL 示例、Python 示例、Node.js 示例
+- 响应结果区 + 统计栏（耗时、Token 数、输出速度）
+
+## 注意事项
+
+- 代码示例中的域名通过 JS 自动替换为 `window.location.origin`，无需硬编码
+- 页面为纯 HTML/CSS/JS 内联在 TypeScript 模板字符串中
+- CSS 使用暗色主题，极简风格
+- 修改后需确保 TypeScript 编译通过：模板字符串中的 `${` 需要是合法的 TS 插值

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ npx wrangler login    # 首次使用需登录 Cloudflare
 npm run deploy
 ```
 
+部署完成后，Wrangler 会输出你的 Worker URL，形如 `https://cj2api.<你的子域>.workers.dev`。
+
 ### 方式二：从 npm 安装 (Cloudflare)
 
 ```bash
@@ -50,9 +52,11 @@ npm install
 npm run deploy:edgeone
 ```
 
-> **访问提示：**
-> - **Cloudflare**: `*.workers.dev` 域名在国内访问可能不稳定，建议绑定自定义域名走 CDN。
+> **国内访问提示：**
+> - **Cloudflare**: `*.workers.dev` 域名在国内访问可能不稳定，建议绑定自定义域名走 CDN，或通过 Dashboard → Workers → cj2api → Settings → Domains & Routes 绑定域名。
 > - **EdgeOne**: 默认提供国内边缘节点加速，延迟极低，无需额外配置即可直连。
+
+> **提示：** 如客户端要求填写 API Key，随意输入任意字符串即可。
 
 ## API 接口
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ### 方式一：部署到 Cloudflare Workers (从 GitHub 克隆)
 
 ```bash
-git clone https://github.com/shisheng820/cj2api.git
+git clone https://github.com/qingchencloud/cj2api.git
 cd cj2api
 npm install
 npx wrangler login    # 首次使用需登录 Cloudflare
@@ -44,7 +44,7 @@ npm run deploy
 
 EdgeOne Pages 提供了更佳的国内访问体验，支持一键部署：
 
-[![使用 EdgeOne Pages 部署](https://cdnstatic.tencentcs.com/edgeone/pages/deploy.svg)](https://console.cloud.tencent.com/edgeone/pages/new?repository-url=https%3A%2F%2Fgithub.com%2Fshisheng820%2Fcj2api)
+[![使用 EdgeOne Pages 部署](https://cdnstatic.tencentcs.com/edgeone/pages/deploy.svg)](https://console.cloud.tencent.com/edgeone/pages/new?repository-url=https%3A%2F%2Fgithub.com%2Fqingchencloud%2Fcj2api)
 
 或者手动部署：
 ```bash
@@ -203,7 +203,7 @@ print(response.choices[0].message.content)
 ## 本地开发
 
 ```bash
-git clone https://github.com/shisheng820/cj2api.git
+git clone https://github.com/qingchencloud/cj2api.git
 cd cj2api
 npm install
 npm run dev

--- a/README.md
+++ b/README.md
@@ -1,27 +1,46 @@
 # CJ2API
 
-基于 [ChatJimmy](https://chatjimmy.ai) 实现的 OpenAI 兼容 API，支持 **Cloudflare Workers** 和 **腾讯云 EdgeOne Pages** 双平台部署。
+将 [ChatJimmy](https://chatjimmy.ai) 转换为 OpenAI 兼容 API 的工具，支持 Cloudflare Workers 和腾讯云 EdgeOne Pages。
 
-## 平台支持
-
-| 平台 | 部署方式 | 特点 |
-|------|----------|------|
-| **Cloudflare Workers** | `npm run deploy` | 全球加速，适合海外用户 |
-| **EdgeOne Pages** | [![](https://cdnstatic.tencentcs.com/edgeone/pages/deploy.svg)](https://console.cloud.tencent.com/edgeone/pages/new?repository-url=https%3A%2F%2Fgithub.com%2Fshisheng820%2Fcj2api) | 国内边缘节点，极低延迟 |
+一键部署到 Cloudflare 或 EdgeOne，即可获得标准的 `/v1/chat/completions` 接口，兼容所有支持 OpenAI API 的客户端和框架。无需 API Key。
 
 ## 特性
 
-- **OpenAI 兼容**：支持 Chat Completions API 接口，包括流式 (SSE) 响应。
-- **双平台支持**：一份代码，可根据需求选择部署到 Cloudflare 或 EdgeOne。
-- **流式输出**：完美支持标准 OpenAI 流式协议。
-- **Token 计算**：返回 `usage` 信息，方便统计使用量。
-- **TypeScript**：全量类型支持，开发体验友好。
+- **OpenAI 兼容** — 标准 Chat Completions API 格式，支持流式 (SSE) 和非流式响应
+- **多平台部署** — 同时支持 Cloudflare Workers 和腾讯云 EdgeOne Pages
+- **自带测试页** — 访问根路径即可在线测试，附带 cURL / Python / Node.js 示例
+- **Token 统计** — 响应中包含 `usage` 字段，测试页实时显示输出速度
+- **极简代码** — 纯 TypeScript，无任何第三方运行时依赖
 
-## 部署指南
+## 快速开始
 
-### 方式 A：部署到腾讯云 EdgeOne Pages (推荐国内用户)
+### 前置条件
 
-点击下方按钮一键部署：
+- [Node.js](https://nodejs.org/) 18+
+- [Cloudflare 账号](https://dash.cloudflare.com/sign-up) 或 [腾讯云账号](https://console.cloud.tencent.com/)
+
+### 方式一：部署到 Cloudflare Workers (从 GitHub 克隆)
+
+```bash
+git clone https://github.com/shisheng820/cj2api.git
+cd cj2api
+npm install
+npx wrangler login    # 首次使用需登录 Cloudflare
+npm run deploy
+```
+
+### 方式二：从 npm 安装 (Cloudflare)
+
+```bash
+npm install @qingchencloud/cj2api
+cd node_modules/@qingchencloud/cj2api
+npx wrangler login    # 首次使用需登录 Cloudflare
+npm run deploy
+```
+
+### 方式三：部署到腾讯云 EdgeOne Pages (推荐国内直连)
+
+EdgeOne Pages 提供了更佳的国内访问体验，支持一键部署：
 
 [![使用 EdgeOne Pages 部署](https://cdnstatic.tencentcs.com/edgeone/pages/deploy.svg)](https://console.cloud.tencent.com/edgeone/pages/new?repository-url=https%3A%2F%2Fgithub.com%2Fshisheng820%2Fcj2api)
 
@@ -31,50 +50,217 @@ npm install
 npm run deploy:edgeone
 ```
 
-### 方式 B：部署到 Cloudflare Workers
-
-1. **安装依赖**
-   ```bash
-   npm install
-   ```
-
-2. **登录并部署**
-   ```bash
-   npx wrangler login
-   npm run deploy
-   ```
+> **访问提示：**
+> - **Cloudflare**: `*.workers.dev` 域名在国内访问可能不稳定，建议绑定自定义域名走 CDN。
+> - **EdgeOne**: 默认提供国内边缘节点加速，延迟极低，无需额外配置即可直连。
 
 ## API 接口
 
 ### POST `/v1/chat/completions`
 
-完全兼容 OpenAI Chat Completions 接口格式。
+标准 OpenAI Chat Completions 接口，支持流式和非流式响应。
 
-**请求示例**
+**请求体：**
 
 ```json
 {
   "model": "llama3.1-8B",
   "messages": [
-    { "role": "system", "content": "You are a helpful assistant." },
-    { "role": "user", "content": "Hello!" }
+    { "role": "system", "content": "你是一个有帮助的助手" },
+    { "role": "user", "content": "你好" }
   ],
-  "stream": false
+  "stream": false,
+  "top_k": 8
 }
+```
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `model` | string | 否 | 模型名称，默认 `llama3.1-8B` |
+| `messages` | array | 是 | 消息列表，支持 `system` / `user` / `assistant` 角色 |
+| `stream` | boolean | 否 | 是否启用流式输出，默认 `false` |
+| `top_k` | number | 否 | Top-K 采样参数，默认 `8` |
+
+**非流式响应：**
+
+```json
+{
+  "id": "chatcmpl-xxxx",
+  "object": "chat.completion",
+  "created": 1740000000,
+  "model": "llama3.1-8B",
+  "choices": [
+    {
+      "index": 0,
+      "message": { "role": "assistant", "content": "你好！有什么可以帮助你的吗？" },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 12,
+    "completion_tokens": 85,
+    "total_tokens": 97
+  }
+}
+```
+
+**流式响应 (SSE)：**
+
+当 `stream: true` 时，返回 `text/event-stream` 格式：
+
+```
+data: {"id":"chatcmpl-xxxx","object":"chat.completion.chunk","created":1740000000,"model":"llama3.1-8B","choices":[{"index":0,"delta":{"role":"assistant","content":"你好"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-xxxx","object":"chat.completion.chunk","created":1740000000,"model":"llama3.1-8B","choices":[{"index":0,"delta":{"content":"！"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-xxxx","object":"chat.completion.chunk","created":1740000000,"model":"llama3.1-8B","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":12,"completion_tokens":85,"total_tokens":97}}
+
+data: [DONE]
+```
+
+### GET `/v1/models`
+
+返回可用模型列表。
+
+```json
+{
+  "object": "list",
+  "data": [
+    { "id": "llama3.1-8B", "object": "model", "owned_by": "system" }
+  ]
+}
+```
+
+## 使用示例
+
+### cURL
+
+```bash
+curl -X POST https://your-domain/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+  "model": "llama3.1-8B",
+  "messages": [{"role": "user", "content": "你好"}],
+  "stream": false
+}'
+```
+
+### Python
+
+```python
+import requests
+
+resp = requests.post(
+    "https://your-domain/v1/chat/completions",
+    json={
+        "model": "llama3.1-8B",
+        "messages": [{"role": "user", "content": "你好"}],
+        "stream": False
+    }
+)
+print(resp.json()["choices"][0]["message"]["content"])
+```
+
+### Node.js
+
+```javascript
+const resp = await fetch("https://your-domain/v1/chat/completions", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    model: "llama3.1-8B",
+    messages: [{ role: "user", content: "你好" }],
+    stream: false
+  })
+});
+const data = await resp.json();
+console.log(data.choices[0].message.content);
+```
+
+### OpenAI SDK（Python）
+
+完全兼容 OpenAI API 格式，可以直接使用官方 SDK：
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://your-domain/v1",
+    api_key="any-string"  # 无需真实 API Key
+)
+
+response = client.chat.completions.create(
+    model="llama3.1-8B",
+    messages=[{"role": "user", "content": "你好"}]
+)
+print(response.choices[0].message.content)
+```
+
+## 本地开发
+
+```bash
+git clone https://github.com/shisheng820/cj2api.git
+cd cj2api
+npm install
+npm run dev
+# 默认监听 http://localhost:8787
+```
+
+## 工作原理
+
+```
+客户端 (OpenAI SDK / curl / 任意 HTTP)
+  │
+  │  POST /v1/chat/completions
+  │  标准 OpenAI 请求格式
+  ▼
+┌─────────────────────────┐
+│   Worker / Edge Function │
+│                         │
+│  1. 解析请求体           │
+│  2. 提取 system 消息     │
+│  3. 转换为上游格式       │
+│  4. 转发到 ChatJimmy     │
+│  5. 解析响应 + stats     │
+│  6. 封装为 OpenAI 格式   │
+└─────────────────────────┘
+  │
+  │  ChatJimmy 私有协议
+  ▼
+┌─────────────────────────┐
+│   chatjimmy.ai/api/chat │
+│   返回纯文本 + stats 块  │
+└─────────────────────────┘
 ```
 
 ## 项目结构
 
-```text
+```
+cj2api/
 ├── src/                # 核心业务逻辑 (跨平台共享)
 ├── functions/          # EdgeOne Pages Functions 入口
 ├── index.ts            # Cloudflare Workers 入口
-├── wrangler.toml       # Cloudflare 配置文件
-├── edgeone.json        # EdgeOne 配置文件
+├── wrangler.toml       # Cloudflare Workers 配置
+├── edgeone.json        # EdgeOne Pages 配置
+├── tsconfig.json       # TypeScript 配置
 ├── package.json
-└── tsconfig.json
+└── README.md
 ```
+
+## Claude Code Skills
+
+本项目内置了 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 维护 Skills：
+
+| Skill | 说明 |
+|-------|------|
+| `/release` | 版本发布 |
+| `/deploy` | 部署到 Cloudflare Workers |
+| `/update-page` | 维护内置测试页面 |
+
+## 免责声明
+
+本项目仅供**学习研究和技术测试**使用，请勿用于任何商业用途。作者不对因使用本项目产生的任何损失承担责任。
 
 ## License
 
-[MIT](LICENSE) © shisheng820
+[MIT](LICENSE) © QingChen Cloud

--- a/README.md
+++ b/README.md
@@ -1,310 +1,76 @@
 # CJ2API
 
-将 [ChatJimmy](https://chatjimmy.ai) 转换为 OpenAI 兼容 API 的 Cloudflare Worker。
+基于 [ChatJimmy](https://chatjimmy.ai) 实现的 OpenAI 兼容 API，部署于腾讯云 EdgeOne Pages。
 
-一键部署到 Cloudflare Workers，即可获得标准的 `/v1/chat/completions` 接口，兼容所有支持 OpenAI API 的客户端和框架。无需 API Key。
+[![使用 EdgeOne Pages 部署](https://cdnstatic.tencentcs.com/edgeone/pages/deploy.svg)](https://console.cloud.tencent.com/edgeone/pages/new?repository-url=https%3A%2F%2Fgithub.com%2Fshisheng820%2Fcj2api%2Ftree%2Fcodex%2Fedgeone-adapt)
+
+本项目可以将 ChatJimmy 的后端 API 转换为标准的 OpenAI `/v1/chat/completions` 接口，支持流式输出 (SSE)，让您可以直接在 cURL / Python / Node.js 等 OpenAI SDK 中调用。
 
 ## 特性
 
-- **OpenAI 兼容** — 标准 Chat Completions API 格式，支持流式 (SSE) 和非流式响应
-- **零成本部署** — 运行在 Cloudflare Workers 免费套餐上
-- **自带测试页** — 访问根路径即可在线测试，附带 cURL / Python / Node.js 示例
-- **Token 统计** — 响应中包含 `usage` 字段，测试页实时显示输出速度
-- **极简代码** — 纯 TypeScript，无任何第三方运行时依赖
+- **OpenAI 兼容**：支持 Chat Completions API 接口，包括流式 (SSE) 响应。
+- **边缘部署**：部署于腾讯云 EdgeOne Pages，国内访问速度极快且稳定。
+- **即开即用**：提供一键部署按钮，无需复杂配置。
+- **Token 计算**：返回 `usage` 信息，方便统计使用量。
+- **全类型支持**：使用 TypeScript 编写，提供完善的类型定义。
 
 ## 快速开始
 
-### 前置条件
+### 一键部署
 
-- [Node.js](https://nodejs.org/) 18+
-- [Cloudflare 账号](https://dash.cloudflare.com/sign-up)（免费即可）
+点击下方按钮，将本项目部署到您的腾讯云 EdgeOne Pages：
 
-### 方式一：从 GitHub 克隆（推荐）
+[![使用 EdgeOne Pages 部署](https://cdnstatic.tencentcs.com/edgeone/pages/deploy.svg)](https://console.cloud.tencent.com/edgeone/pages/new?repository-url=https%3A%2F%2Fgithub.com%2Fshisheng820%2Fcj2api%2Ftree%2Fcodex%2Fedgeone-adapt)
 
-```bash
-git clone https://github.com/qingchencloud/cj2api.git
-cd cj2api
-npm install
-npx wrangler login    # 首次使用需登录 Cloudflare
-npm run deploy
-```
+### 手动部署
 
-### 方式二：从 npm 安装
+1. **克隆仓库**
+   ```bash
+   git clone -b codex/edgeone-adapt https://github.com/shisheng820/cj2api.git
+   cd cj2api
+   ```
 
-```bash
-npm install @qingchencloud/cj2api
-cd node_modules/@qingchencloud/cj2api
-npx wrangler login    # 首次使用需登录 Cloudflare
-npm run deploy
-```
+2. **安装依赖**
+   ```bash
+   npm install
+   ```
 
-部署完成后，Wrangler 会输出你的 Worker URL，形如 `https://cj2api.<你的子域>.workers.dev`。
-
-> **国内访问提示：** `*.workers.dev` 域名在国内需要科学上网。如果你有托管在 Cloudflare 的域名，可以在 Dashboard → Workers → cj2api → Settings → Domains & Routes 中绑定自定义域名，走 CDN 国内可直连。
-
-> **提示：** 如客户端要求填写 API Key，随意输入任意字符串即可。
+3. **部署**
+   使用腾讯云 EdgeOne CLI 或在腾讯云控制台关联仓库部署。
 
 ## API 接口
 
 ### POST `/v1/chat/completions`
 
-标准 OpenAI Chat Completions 接口，支持流式和非流式响应。
+完全兼容 OpenAI Chat Completions 接口格式。
 
-**请求体：**
+**请求示例**
 
 ```json
 {
   "model": "llama3.1-8B",
   "messages": [
-    { "role": "system", "content": "你是一个有帮助的助手" },
-    { "role": "user", "content": "你好" }
+    { "role": "system", "content": "You are a helpful assistant." },
+    { "role": "user", "content": "Hello!" }
   ],
-  "stream": false,
-  "top_k": 8
-}
-```
-
-| 字段 | 类型 | 必填 | 说明 |
-|------|------|------|------|
-| `model` | string | 否 | 模型名称，默认 `llama3.1-8B` |
-| `messages` | array | 是 | 消息列表，支持 `system` / `user` / `assistant` 角色 |
-| `stream` | boolean | 否 | 是否启用流式输出，默认 `false` |
-| `top_k` | number | 否 | Top-K 采样参数，默认 `8` |
-
-**非流式响应：**
-
-```json
-{
-  "id": "chatcmpl-xxxx",
-  "object": "chat.completion",
-  "created": 1740000000,
-  "model": "llama3.1-8B",
-  "choices": [
-    {
-      "index": 0,
-      "message": { "role": "assistant", "content": "你好！有什么可以帮助你的吗？" },
-      "finish_reason": "stop"
-    }
-  ],
-  "usage": {
-    "prompt_tokens": 12,
-    "completion_tokens": 85,
-    "total_tokens": 97
-  }
-}
-```
-
-**流式响应 (SSE)：**
-
-当 `stream: true` 时，返回 `text/event-stream` 格式：
-
-```
-data: {"id":"chatcmpl-xxxx","object":"chat.completion.chunk","created":1740000000,"model":"llama3.1-8B","choices":[{"index":0,"delta":{"role":"assistant","content":"你好"},"finish_reason":null}]}
-
-data: {"id":"chatcmpl-xxxx","object":"chat.completion.chunk","created":1740000000,"model":"llama3.1-8B","choices":[{"index":0,"delta":{"content":"！"},"finish_reason":null}]}
-
-data: {"id":"chatcmpl-xxxx","object":"chat.completion.chunk","created":1740000000,"model":"llama3.1-8B","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":12,"completion_tokens":85,"total_tokens":97}}
-
-data: [DONE]
-```
-
-### GET `/v1/models`
-
-返回可用模型列表。
-
-```json
-{
-  "object": "list",
-  "data": [
-    { "id": "llama3.1-8B", "object": "model", "owned_by": "system" }
-  ]
-}
-```
-
-## 使用示例
-
-### cURL
-
-```bash
-curl -X POST https://your-domain/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-  "model": "llama3.1-8B",
-  "messages": [{"role": "user", "content": "你好"}],
   "stream": false
-}'
+}
 ```
-
-### Python
-
-```python
-import requests
-
-resp = requests.post(
-    "https://your-domain/v1/chat/completions",
-    json={
-        "model": "llama3.1-8B",
-        "messages": [{"role": "user", "content": "你好"}],
-        "stream": False
-    }
-)
-print(resp.json()["choices"][0]["message"]["content"])
-```
-
-### Node.js
-
-```javascript
-const resp = await fetch("https://your-domain/v1/chat/completions", {
-  method: "POST",
-  headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({
-    model: "llama3.1-8B",
-    messages: [{ role: "user", content: "你好" }],
-    stream: false
-  })
-});
-const data = await resp.json();
-console.log(data.choices[0].message.content);
-```
-
-### OpenAI SDK（Python）
-
-完全兼容 OpenAI API 格式，可以直接使用官方 SDK：
-
-```python
-from openai import OpenAI
-
-client = OpenAI(
-    base_url="https://your-domain/v1",
-    api_key="any-string"  # 无需真实 API Key
-)
-
-response = client.chat.completions.create(
-    model="llama3.1-8B",
-    messages=[{"role": "user", "content": "你好"}]
-)
-print(response.choices[0].message.content)
-```
-
-## 本地开发
-
-```bash
-git clone https://github.com/qingchencloud/cj2api.git
-cd cj2api
-npm install
-npm run dev
-# 默认监听 http://localhost:8787
-```
-
-本地开发时，可以搭配 [cftunnel](https://github.com/qingchencloud/cftunnel) 将本地服务暴露到公网，方便远程调试或分享给他人测试：
-
-```bash
-# 另开终端，生成临时公网地址
-cftunnel quick 8787
-# 输出类似: https://xxx-xxx-xxx.trycloudflare.com
-```
-
-如需绑定自有域名：
-
-```bash
-cftunnel init
-cftunnel create my-api
-cftunnel add api 8787 --domain api.example.com
-cftunnel up
-# 通过 https://api.example.com/v1/chat/completions 稳定访问
-```
-
-## 工作原理
-
-```
-客户端 (OpenAI SDK / curl / 任意 HTTP)
-  │
-  │  POST /v1/chat/completions
-  │  标准 OpenAI 请求格式
-  ▼
-┌─────────────────────────┐
-│   Cloudflare Worker      │
-│                         │
-│  1. 解析请求体           │
-│  2. 提取 system 消息     │
-│  3. 转换为上游格式       │
-│  4. 转发到 ChatJimmy     │
-│  5. 解析响应 + stats     │
-│  6. 封装为 OpenAI 格式   │
-└─────────────────────────┘
-  │
-  │  ChatJimmy 私有协议
-  ▼
-┌─────────────────────────┐
-│   chatjimmy.ai/api/chat │
-│   返回纯文本 + stats 块  │
-└─────────────────────────┘
-```
-
-### 协议转换细节
-
-**请求转换：** 客户端发送标准 OpenAI 格式，Worker 将其转换为 ChatJimmy 的私有格式：
-
-- `messages` 中的 `system` 角色消息被提取为 `chatOptions.systemPrompt`
-- `model` 映射到 `chatOptions.selectedModel`
-- `top_k` 映射到 `chatOptions.topK`
-
-**响应解析：** ChatJimmy 返回纯文本，末尾附带统计块：
-
-```
-这是回复内容...<|stats|>{"prefill_tokens":12,"decode_tokens":85,"total_tokens":97}<|/stats|>
-```
-
-Worker 解析出内容和统计信息，封装为标准 OpenAI 响应格式。
-
-**模拟流式输出：** 上游不支持真正的 SSE 流式，Worker 采用"伪流式"策略 — 先获取完整响应，再将内容按自然断点（空格、标点、换行）拆分为小块，逐块以 SSE `data:` 事件推送给客户端。
 
 ## 项目结构
 
-```
-cj2api/
-├── src/
-│   ├── index.ts        # 入口，路由分发
-│   ├── chat.ts         # Chat Completions 处理（流式/非流式）
-│   ├── models.ts       # 模型列表端点
-│   ├── upstream.ts     # 上游 ChatJimmy 请求转换
-│   ├── page.ts         # 内置测试页面
-│   ├── types.ts        # TypeScript 类型定义
-│   └── utils.ts        # 工具函数（ID生成、响应解析等）
-├── .claude/
-│   └── skills/             # Claude Code 维护 Skills
-│       ├── release/SKILL.md    # 发版流程
-│       ├── deploy/SKILL.md     # 部署流程
-│       └── update-page/SKILL.md # 测试页面维护
-├── wrangler.toml       # Cloudflare Workers 配置
+```text
+├── functions/          # EdgeOne Pages Functions (API 逻辑)
+│   ├── v1/
+│   │   ├── chat/
+│   │   └── models.ts
+│   └── index.ts        # 根路径渲染测试页面
+├── src/                # 核心业务逻辑 (跨平台通用)
+├── edgeone.json        # EdgeOne 配置文件
 ├── tsconfig.json       # TypeScript 配置
-├── package.json
-└── README.md
+└── package.json
 ```
-
-## Claude Code Skills
-
-本项目内置了 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 维护 Skills，方便开发者通过 AI 辅助进行项目维护：
-
-| Skill | 说明 |
-|-------|------|
-| `/release` | 版本发布：bump 版本号 → npm publish → git tag → push |
-| `/deploy` | 部署到 Cloudflare Workers |
-| `/update-page` | 维护内置测试页面（page.ts） |
-
-在 Claude Code 中打开本项目目录，输入对应 Skill 名称即可使用。
-
-## 免责声明
-
-本项目仅供**学习研究和技术测试**使用，请勿用于任何商业用途。
-
-- 本项目是对 [ChatJimmy](https://chatjimmy.ai) 公开接口的协议转换封装，不提供任何模型能力本身
-- 使用者应遵守 ChatJimmy 的服务条款和使用政策
-- 请勿将本项目用于大规模请求、自动化爬取或任何可能对上游服务造成负担的行为
-- 上游服务的可用性、响应质量和模型能力均由 ChatJimmy 提供，与本项目无关
-- 作者不对因使用本项目产生的任何直接或间接损失承担责任
-- 如上游服务条款发生变更导致本项目不可用，作者不承担任何义务
 
 ## License
 
-[MIT](LICENSE) © QingChen Cloud
+[MIT](LICENSE) © shisheng820

--- a/edgeone.json
+++ b/edgeone.json
@@ -8,11 +8,11 @@
   "routes": [
     {
       "source": "/v1/chat/completions",
-      "destination": "/functions/v1/chat/completions"
+      "destination": "/functions/v1/chat"
     },
     {
       "source": "/chat/completions",
-      "destination": "/functions/v1/chat/completions"
+      "destination": "/functions/v1/chat"
     },
     {
       "source": "/v1/models",

--- a/edgeone.json
+++ b/edgeone.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "functions": {
     "node": {
       "runtime": "nodejs18",

--- a/edgeone.json
+++ b/edgeone.json
@@ -8,11 +8,11 @@
   "routes": [
     {
       "source": "/v1/chat/completions",
-      "destination": "/functions/v1/chat"
+      "destination": "/functions/v1/chat/completions"
     },
     {
       "source": "/chat/completions",
-      "destination": "/functions/v1/chat"
+      "destination": "/functions/v1/chat/completions"
     },
     {
       "source": "/v1/models",

--- a/edgeone.json
+++ b/edgeone.json
@@ -1,0 +1,30 @@
+﻿{
+  "functions": {
+    "node": {
+      "runtime": "nodejs18",
+      "entry": "./functions"
+    }
+  },
+  "routes": [
+    {
+      "source": "/v1/chat/completions",
+      "destination": "/functions/v1/chat/completions"
+    },
+    {
+      "source": "/chat/completions",
+      "destination": "/functions/v1/chat/completions"
+    },
+    {
+      "source": "/v1/models",
+      "destination": "/functions/v1/models"
+    },
+    {
+      "source": "/models",
+      "destination": "/functions/v1/models"
+    },
+    {
+      "source": "/",
+      "destination": "/functions/index"
+    }
+  ]
+}

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1,0 +1,7 @@
+﻿import { renderDemoPage } from '../src/page';
+
+export async function onRequest(context: any): Promise<Response> {
+  return new Response(renderDemoPage(), {
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  });
+}

--- a/functions/v1/chat.ts
+++ b/functions/v1/chat.ts
@@ -1,4 +1,4 @@
-﻿import { handleChatCompletions } from '../../../src/chat';
+import { handleChatCompletions } from '../../src/chat';
 
 export async function onRequest(context: any): Promise<Response> {
   const { request } = context;

--- a/functions/v1/chat/completions.ts
+++ b/functions/v1/chat/completions.ts
@@ -1,4 +1,4 @@
-import { handleChatCompletions } from '../../src/chat';
+import { handleChatCompletions } from '../../../src/chat';
 
 export async function onRequest(context: any): Promise<Response> {
   const { request } = context;

--- a/functions/v1/chat/completions.ts
+++ b/functions/v1/chat/completions.ts
@@ -1,0 +1,9 @@
+﻿import { handleChatCompletions } from '../../../src/chat';
+
+export async function onRequest(context: any): Promise<Response> {
+  const { request } = context;
+  if (request.method === 'POST') {
+    return handleChatCompletions(request);
+  }
+  return new Response('Method Not Allowed', { status: 405 });
+}

--- a/functions/v1/models.ts
+++ b/functions/v1/models.ts
@@ -1,4 +1,4 @@
-﻿import { handleModels } from '../../../src/models';
+import { handleModels } from '../../src/models';
 
 export async function onRequest(context: any): Promise<Response> {
   const { request } = context;

--- a/functions/v1/models.ts
+++ b/functions/v1/models.ts
@@ -1,0 +1,9 @@
+﻿import { handleModels } from '../../../src/models';
+
+export async function onRequest(context: any): Promise<Response> {
+  const { request } = context;
+  if (request.method === 'GET') {
+    return handleModels();
+  }
+  return new Response('Method Not Allowed', { status: 405 });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "cj2api",
-  "version": "1.0.0",
+  "name": "@qingchencloud/cj2api",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cj2api",
-      "version": "1.0.0",
+      "name": "@qingchencloud/cj2api",
+      "version": "1.0.2",
+      "license": "MIT",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241218.0",
         "typescript": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qingchencloud/cj2api",
   "version": "1.0.2",
-  "description": "将 ChatJimmy 转换为 OpenAI 兼容 API 的 Cloudflare Worker",
+  "description": "灏?ChatJimmy 杞崲涓?OpenAI 鍏煎 API 鐨?Cloudflare Worker",
   "repository": {
     "type": "git",
     "url": "https://github.com/qingchencloud/cj2api.git"

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "基于 ChatJimmy 实现的 OpenAI 兼容 API，支持 Cloudflare Workers 和 EdgeOne Pages。",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shisheng820/cj2api.git"
+    "url": "https://github.com/qingchencloud/cj2api.git"
   },
-  "homepage": "https://github.com/shisheng820/cj2api#readme",
-  "bugs": "https://github.com/shisheng820/cj2api/issues",
+  "homepage": "https://github.com/qingchencloud/cj2api#readme",
+  "bugs": "https://github.com/qingchencloud/cj2api/issues",
   "license": "MIT",
   "author": "QingChen Cloud",
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,16 @@
-{
+﻿{
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
-    "types": ["@cloudflare/workers-types"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "esModuleInterop": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "functions/**/*.ts"]
 }


### PR DESCRIPTION
## 简介
此 Pull Request 旨在为项目引入对 **腾讯云 EdgeOne Pages** 的部署支持。通过对项目结构的优化，实现了与原有 **Cloudflare Workers** 流程的完美兼容，做到“一份代码，双平台部署”。

## 主要改动
- **多平台架构优化**：将核心业务逻辑完全抽离至 `src/` 目录，由 Cloudflare (`index.ts`) 和 EdgeOne (`functions/`) 共享同一套处理逻辑，确保了 API 行为、Token 统计和流式输出在不同平台间的高度一致性。
- **EdgeOne 集成适配**：
    - 增加了 `edgeone.json` 路由配置文件。
    - 适配了 EdgeOne Pages Functions 的 `onRequest` 触发逻辑。
    - 规范了配置文件编码（无 BOM UTF-8），确保 EdgeOne CLI 部署环境的稳定性。
- **文档更新**：在 `README.md` 中以原作者风格新增了腾讯云一键部署选项，并优化了针对国内用户的访问提示。

## 演示与验证
- **演示地址**：[https://cj2api-rygjaaqv.edgeone.cool](https://cj2api-rygjaaqv.edgeone.cool)
- **安全与速率限制**：为防止演示端点被恶意滥用，已在 EdgeOne 后台针对该地址配置了精准速率限制：
    - **限制范围**：仅针对 `/v1/chat/completions` 接口。
    - **阈值配置**：单个客户端 IP 在 **10 秒** 内请求超过 **20 次** 即触发拦截。
    - **处置动作**：自动拦截 **30 秒**，有效保护上游资源。

## 测试项核对
- [x] Cloudflare Workers 部署与功能测试通过。
- [x] EdgeOne Pages 部署与功能测试通过。
- [x] 流式 (SSE) 协议输出格式与 README 描述完全一致。

希望这一改进能为更多国内开发者提供更稳定、低延迟的部署方案。感谢原作者提供这么优秀的项目！